### PR TITLE
fix: Use require.resolve when yarn v2 is detected

### DIFF
--- a/packages/server/lib/util/resolve.js
+++ b/packages/server/lib/util/resolve.js
@@ -13,7 +13,6 @@ module.exports = {
    */
   typescript: (projectRoot) => {
     if (env.get('CYPRESS_INTERNAL_NO_TYPESCRIPT') === '1' || !projectRoot) {
-      debug('skipping typescript resolution')
       return null
     }
 

--- a/packages/server/lib/util/resolve.js
+++ b/packages/server/lib/util/resolve.js
@@ -1,6 +1,8 @@
 const resolve = require('resolve')
 const env = require('./env')
 const debug = require('debug')('cypress:server:plugins')
+const fs = require('fs')
+const path = require('path')
 
 module.exports = {
   /**
@@ -11,6 +13,7 @@ module.exports = {
    */
   typescript: (projectRoot) => {
     if (env.get('CYPRESS_INTERNAL_NO_TYPESCRIPT') === '1' || !projectRoot) {
+      debug('skipping typescript resolution')
       return null
     }
 
@@ -21,7 +24,10 @@ module.exports = {
 
       debug('resolving typescript with options %o', options)
 
-      const resolved = resolve.sync('typescript', options)
+      // use built-in resolve when yarn v2 is detected
+      const resolved = fs.existsSync(path.join(projectRoot, '.yarn', 'cache')) ?
+        require.resolve('typescript') :
+        resolve.sync('typescript', options)
 
       debug('resolved typescript %s', resolved)
 


### PR DESCRIPTION
<!-- Thanks for contributing! PLEASE...
- Read our contributing guidelines: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md 
- Read our Code Review Checklist on coding standards and what needs to be done before a PR can be merged: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#Code-Review-Checklist
- Mark this PR as "Draft" if it is not ready for review.
- Make sure you set the correct base branch based on what packages you're changing: https://github.com/cypress-io/cypress/blob/develop/CONTRIBUTING.md#branches
-->

- Closes <!-- issue number here. e.g. "Closes #1234" -->

### User facing changelog
Fixes support for Typescript pluginsFile when using Yarn PnP

### Additional details
- Currently, using Yarn PnP breaks support for loading typescript plugin files with a cryptic error message (just loads the file as if it were javascript)
- This change modifies the resolve function when detecting typescript to use the extensible resolver when Yarn v2 is detected

### How has the user experience changed?
Before:
<img width="990" alt="Screen Shot 2021-03-22 at 2 11 45 PM" src="https://user-images.githubusercontent.com/75641375/112059187-c5445d80-8b18-11eb-9481-2f3354011e1a.png">
After:
[no error]

### PR Tasks
<!-- These tasks must be completed before a PR is merged.
Delete tasks if they are not applicable. -->

- [ ] Have tests been added/updated?
- [ ] Has the original issue or this PR been tagged with a release in ZenHub? <!-- (internal team only)-->
- [ ] Has a PR for user-facing changes been opened in [`cypress-documentation`](https://github.com/cypress-io/cypress-documentation)? <!-- Link to PR here -->
